### PR TITLE
Moved browser to chromium and changed base runner image to support arm builds

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -15,6 +15,9 @@ jobs:
     name: Build Edge Image
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -42,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -90,7 +93,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,11 @@ FROM golang:1.25.0 AS base
 FROM base AS builder
     RUN go build -o /stream ./cmd/main.go
 
-# Download Chrome in a separate stage so it's done parallel to the rest of the build
-FROM curlimages/curl:latest AS downloader
-    RUN curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-        -o google-chrome-stable_current_amd64.deb
-
-# Run using FFmpeg image with Chrome support
-FROM linuxserver/ffmpeg:7.1.1 AS runner
-    # Install runtime dependencies
+# Run using Chromium image with FFmpeg support
+FROM linuxserver/chromium:latest AS runner
+    # Install FFmpeg and runtime dependencies
     RUN apt-get update && apt-get install -y \
+        ffmpeg \
         xvfb \
         x11-utils \
         pulseaudio \
@@ -28,13 +24,6 @@ FROM linuxserver/ffmpeg:7.1.1 AS runner
         alsa-utils \
         libasound2-plugins \
         dbus \
-        && rm -rf /var/lib/apt/lists/*
-
-    # Install Chrome from downloaded .deb
-    COPY --from=downloader /home/curl_user/google-chrome-stable_current_amd64.deb /tmp/google-chrome-stable_current_amd64.deb
-    RUN apt-get update \
-        && apt-get install -y /tmp/google-chrome-stable_current_amd64.deb \
-        && rm /tmp/google-chrome-stable_current_amd64.deb \
         && rm -rf /var/lib/apt/lists/*
 
     # Create directories for audio configs


### PR DESCRIPTION
- Changed the base image to `linuxserver/chromium:latest` to provide easy access to chromium browsers in both `amd64` and `arm64`
- Added `apt-get` install of `ffmpeg`
- Updated build pipelines so `edge` and release builds produce both architectures