### PR TITLE
Use native multi-arch Docker builds via reusable workflow

### DIFF
--- a/.github/workflows/docker-multiarch.yaml
+++ b/.github/workflows/docker-multiarch.yaml
@@ -1,0 +1,124 @@
+# Reusable multi-arch Docker build workflow.
+# Builds linux/amd64 and linux/arm64 on native runners, then merges into one manifest.
+name: Build Multi-Arch Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Full image name (e.g. ghcr.io/org/repo)
+        required: true
+        type: string
+      tags:
+        description: docker/metadata-action tags config applied to the final manifest
+        required: true
+        type: string
+      merge_job_name:
+        description: Display name for the manifest merge job
+        required: false
+        type: string
+        default: Publish Multi-Arch Image
+      build_job_name_prefix:
+        description: Prefix for per-platform build job names
+        required: false
+        type: string
+        default: Build Image
+
+jobs:
+  build:
+    name: ${{ inputs.build_job_name_prefix }} (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ inputs.image }}
+          tags: |
+            type=sha,format=long
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: ${{ inputs.merge_job_name }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          name: digests
+          path: /tmp/digests
+
+      - name: Generate Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ inputs.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          TAGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAGS="${TAGS} -t ${tag}"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
+          docker buildx imagetools create \
+            ${TAGS} \
+            $(printf '${{ inputs.image }}@sha256:%s ' *)

--- a/.github/workflows/docker-multiarch.yaml
+++ b/.github/workflows/docker-multiarch.yaml
@@ -11,8 +11,19 @@ on:
         type: string
       tags:
         description: docker/metadata-action tags config applied to the final manifest
-        required: true
+        required: false
         type: string
+        default: ""
+      publish:
+        description: Push images to the registry and create a multi-arch manifest
+        required: false
+        type: boolean
+        default: true
+      export_integration_image:
+        description: Export the amd64 build as a docker tar artifact for integration tests (publish must be false)
+        required: false
+        type: boolean
+        default: false
       merge_job_name:
         description: Display name for the manifest merge job
         required: false
@@ -44,6 +55,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
+        if: inputs.publish
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -51,6 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Docker Metadata
+        if: inputs.publish
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -59,6 +72,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push by digest
+        if: inputs.publish
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -70,12 +84,14 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
       - name: Export digest
+        if: inputs.publish
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
           name: digests
@@ -83,9 +99,40 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Build and export for integration tests
+        if: ${{ !inputs.publish && inputs.export_integration_image && matrix.platform == 'linux/amd64' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: ${{ inputs.image }}:test-${{ github.run_id }}
+          outputs: type=docker,dest=/tmp/stream-webpage-${{ github.run_id }}.tar
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Upload Docker image artifact
+        if: ${{ !inputs.publish && inputs.export_integration_image && matrix.platform == 'linux/amd64' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-image-${{ github.run_id }}
+          path: /tmp/stream-webpage-${{ github.run_id }}.tar
+          retention-days: 1
+
+      - name: Build for validation
+        if: ${{ !inputs.publish && !(inputs.export_integration_image && matrix.platform == 'linux/amd64') }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
   merge:
     name: ${{ inputs.merge_job_name }}
     needs: build
+    if: inputs.publish
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -10,42 +10,19 @@ on:
     branches:
       - main
 
+env:
+  IMAGE: ghcr.io/zozman/stream-webpage-container
+
 jobs:
-  edge:
+  build-image:
     name: Build Edge Image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Generate Docker Metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/zozman/stream-webpage-container
-          tags: |
-            type=raw,value=edge
-            type=sha
-            type=sha,format=long
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push Docker Image to GitHub Container Registries
-        uses: docker/build-push-action@v7
-        with:
-          push: true
-          platforms: linux/amd64,linux/arm64
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    uses: ./.github/workflows/docker-multiarch.yaml
+    secrets: inherit
+    with:
+      image: ${{ env.IMAGE }}
+      merge_job_name: Build Edge Image
+      build_job_name_prefix: Build Edge Image
+      tags: |
+        type=raw,value=edge
+        type=sha
+        type=sha,format=long

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,33 +41,14 @@ jobs:
 
   build-image:
     name: Build Test Docker Image
-    runs-on: ubuntu-latest
     needs: test
     if: needs.test.result == 'success'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-    
-    - name: Build and cache Docker image
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        push: false
-        tags: stream-webpage:test-${{ github.run_id }}
-        outputs: type=docker,dest=/tmp/stream-webpage-${{ github.run_id }}.tar
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-    
-    - name: Upload Docker image artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: docker-image-${{ github.run_id }}
-        path: /tmp/stream-webpage-${{ github.run_id }}.tar
-        retention-days: 1
+    uses: ./.github/workflows/docker-multiarch.yaml
+    with:
+      image: stream-webpage
+      publish: false
+      export_integration_image: true
+      build_job_name_prefix: Build Test Docker Image
 
   integration-test:
     name: "Integration Test: ${{ matrix.name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  IMAGE: ghcr.io/zozman/stream-webpage-container
+
 jobs:
   wait-for-edge:
     name: Wait for Edge Workflows
@@ -20,22 +23,18 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.6.1
         with:
           ref: ${{ github.sha }}
-          check-name: 'Build Edge Image'
+          check-name: 'Build Edge Image / Build Edge Image'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
           allowed-conclusions: success,failure,cancelled,skipped
 
-  release:
-    name: Create Release
+  check-image:
+    name: Check For Existing Edge Image
     runs-on: ubuntu-latest
     needs: wait-for-edge
+    outputs:
+      image_exists: ${{ steps.check_image.outputs.image_exists }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -50,51 +49,71 @@ jobs:
         id: check_image
         run: |
           echo "Checking for edge image with SHA: ${{ github.sha }}"
-          
-          # Check if image with current SHA exists
-          if docker manifest inspect ghcr.io/zozman/stream-webpage-container:sha-${{ github.sha }} >/dev/null 2>&1; then
+
+          if docker manifest inspect ${{ env.IMAGE }}:sha-${{ github.sha }} >/dev/null 2>&1; then
             echo "Edge image found for SHA ${{ github.sha }}"
-            echo "image_exists=true" >> $GITHUB_OUTPUT
+            echo "image_exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "No edge image found for SHA ${{ github.sha }}"
-            echo "image_exists=false" >> $GITHUB_OUTPUT
+            echo "image_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+  retag-image:
+    name: Re-tag Existing Image
+    runs-on: ubuntu-latest
+    needs: check-image
+    if: needs.check-image.outputs.image_exists == 'true'
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Re-tag Existing Image
-        if: steps.check_image.outputs.image_exists == 'true'
         run: |
           echo "Re-tagging existing multi-platform image..."
-          
-          # Use buildx imagetools to create new tags that reference the same multi-platform manifest
-          # This preserves both amd64 and arm64 platforms
-          docker buildx imagetools create --tag ghcr.io/zozman/stream-webpage-container:latest ghcr.io/zozman/stream-webpage-container:sha-${{ github.sha }}
-          docker buildx imagetools create --tag ghcr.io/zozman/stream-webpage-container:${{ github.ref_name }} ghcr.io/zozman/stream-webpage-container:sha-${{ github.sha }}
 
-      - name: Generate Docker Metadata For New Build
-        if: steps.check_image.outputs.image_exists == 'false'
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/zozman/stream-webpage-container
-          tags: |
-            type=raw,value=latest
-            type=raw,value=${{ github.ref_name }}
-            type=sha
-            type=sha,format=long
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE }}:latest \
+            --tag ${{ env.IMAGE }}:${{ github.ref_name }} \
+            ${{ env.IMAGE }}:sha-${{ github.sha }}
 
-      - name: Build & Push New Docker Image
-        if: steps.check_image.outputs.image_exists == 'false'
-        uses: docker/build-push-action@v7
-        with:
-          push: true
-          platforms: linux/amd64,linux/arm64
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  build-image:
+    name: Build Release Image
+    needs: check-image
+    if: needs.check-image.outputs.image_exists == 'false'
+    uses: ./.github/workflows/docker-multiarch.yaml
+    secrets: inherit
+    with:
+      image: ${{ env.IMAGE }}
+      merge_job_name: Publish Release Image
+      build_job_name_prefix: Build Release Image
+      tags: |
+        type=raw,value=latest
+        type=raw,value=${{ github.ref_name }}
+        type=sha
+        type=sha,format=long
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [check-image, retag-image, build-image]
+    if: |
+      always() &&
+      needs.check-image.result == 'success' &&
+      (needs.retag-image.result == 'success' || needs.build-image.result == 'success')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Docker Actions Summary
         run: |
-          if [ "${{ steps.check_image.outputs.image_exists }}" == "true" ]; then
+          if [ "${{ needs.check-image.outputs.image_exists }}" == "true" ]; then
             echo "✅ Successfully re-tagged existing edge image"
             echo "🏷️  Tags: latest, ${{ github.ref_name }}"
           else
@@ -111,12 +130,12 @@ jobs:
             ## Release ${{ github.ref_name }}
             
             🐳 **Docker Images:**
-            - `ghcr.io/zozman/stream-webpage-container:latest`
-            - `ghcr.io/zozman/stream-webpage-container:${{ github.ref_name }}`
+            - `${{ env.IMAGE }}:latest`
+            - `${{ env.IMAGE }}:${{ github.ref_name }}`
             
             📝 **Image Details:**
             - **SHA:** `${{ github.sha }}`
-            - **Built from:** ${{ steps.check_image.outputs.image_exists == 'true' && 'Re-tagged existing edge image' || 'Freshly built image' }}
+            - **Built from:** ${{ needs.check-image.outputs.image_exists == 'true' && 'Re-tagged existing edge image' || 'Freshly built image' }}
             
             ## What's Changed
             See the [commit history](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for detailed changes.


### PR DESCRIPTION
## Summary
- Add a reusable `docker-multiarch.yaml` workflow that builds `linux/amd64` and `linux/arm64` on native runners, pushes by digest, and merges into a single multi-arch manifest.
- Simplify `edge.yaml` and the release fallback build path to call the shared workflow instead of duplicating build logic.
- Remove QEMU-based cross-compilation for container builds and add per-platform GHA cache scopes for faster rebuilds.

## Test plan
- [ ] Merge to `main` and confirm the edge workflow completes on both `ubuntu-latest` and `ubuntu-24.04-arm` runners
- [ ] Verify `ghcr.io/zozman/stream-webpage-container:edge` manifest includes both `linux/amd64` and `linux/arm64`
- [ ] Tag a release and confirm the release workflow waits for `Build Edge Image / Build Edge Image`, then re-tags or builds as expected


Made with [Cursor](https://cursor.com)